### PR TITLE
reverse xpGains before get skillId

### DIFF
--- a/main.py
+++ b/main.py
@@ -117,7 +117,7 @@ learningLanguage = data['learningLanguage']
 xpGains = data['xpGains']
 
 skillId = None
-for xpGain in xpGains:
+for xpGain in list(reversed(xpGains)):
     if 'skillId' in xpGain:
         skillId = xpGain['skillId']
         break


### PR DESCRIPTION
When the lesson is completed, a new skilId is created at the end of the array. At the beginning of the array it often happens that skillId is equal to None and because of this it gives an error